### PR TITLE
lcovonly

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Add a `coverage-ci` script target in `package.json` something like:
 
     "coverage-ci": "cross-env NODE_ENV=test nyc --reporter=lcovonly npm run test-node",
 
-Note the `lcovonly` reporter. The default setup will use `./coverage/lcov.info`.
+Note the `lcovonly` reporter. The default CI setup will use the
+`./coverage/lcov.info` file that is generated.
 
 Ensure `package.json` or nyc config is setup something like:
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ Where MODE is one of:
 
 If you are using lint support:
 
-    npm i -D eslint
-    npm i -D eslint-config-digitalbazaar
+    npm i -D eslint eslint-config-digitalbazaar
     # optional: eslint-plugin-jsdoc
     # optional: eslint-plugin-vue
 

--- a/README.md
+++ b/README.md
@@ -7,16 +7,18 @@ Script to help setup a repo with continuous integration support.
 
 ## Usage
 
-From your source dir, run:
+You may put the `setup-ci` script in your `PATH` or run it directly.
 
-    ../ci-script/setup-ci MODE
+Run the following to setup CI support:
+
+    setup-ci MODE
 
 Where MODE is one of:
 
-- bedrock
-- bedrock-web
-- isomorphic
-- lint
+- `bedrock`
+- `bedrock-web`
+- `isomorphic`
+- `lint`
 
 ## Lint
 
@@ -26,11 +28,17 @@ If you are using lint support:
     npm i -D eslint-config-digitalbazaar
     # optional: eslint-plugin-jsdoc
     # optional: eslint-plugin-vue
-    # setup a .eslintrc.js
 
-Add a `"script"` target something like:
+Setup `.eslintrc.js`. See [eslint-config-digitalbazaar][] or other projects for
+examples.
+
+Add a `lint` script target in `package.json` something like:
 
     "lint": "eslint ."
+
+If you are also linting `.vue` files, then use something like:
+
+    "lint": "eslint \"**/*.{js,vue}\""
 
 ## Coverage
 
@@ -38,20 +46,18 @@ If you are using coverage support:
 
     npm i -D nyc
 
-Add a `"script"` target something like:
+Add a `coverage-ci` script target in `package.json` something like:
 
     "coverage-ci": "cross-env NODE_ENV=test nyc --reporter=lcovonly npm run test-node",
 
 Note the `lcovonly` reporter. The default setup will use `./coverage/lcov.info`.
 
-Ensure package.json or nyc config is setup something like:
+Ensure `package.json` or nyc config is setup something like:
 
     "nyc": {
       "exclude": [
         "tests"
-      ],
-      "reporter": [
-        "html",
-        "text-summary"
       ]
     }
+
+[eslint-config-digitalbazaar]: https://github.com/digitalbazaar/eslint-config-digitalbazaar/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,57 @@
 # ci-script
+
+Script to help setup a repo with continuous integration support.
+
+- Uses GitHub Actions.
+- Actions configs for different setups.
+
+## Usage
+
+From your source dir, run:
+
+    ../ci-script/setup-ci MODE
+
+Where MODE is one of:
+
+- bedrock
+- bedrock-web
+- isomorphic
+- lint
+
+## Lint
+
+If you are using lint support:
+
+    npm i -D eslint
+    npm i -D eslint-config-digitalbazaar
+    # optional: eslint-plugin-jsdoc
+    # optional: eslint-plugin-vue
+    # setup a .eslintrc.js
+
+Add a `"script"` target something like:
+
+    "lint": "eslint ."
+
+## Coverage
+
+If you are using coverage support:
+
+    npm i -D nyc
+
+Add a `"script"` target something like:
+
+    "coverage-ci": "cross-env NODE_ENV=test nyc --reporter=lcovonly npm run test-node",
+
+Note the `lcovonly` reporter. The default setup will use `./coverage/lcov.info`.
+
+Ensure package.json or nyc config is setup something like:
+
+    "nyc": {
+      "exclude": [
+        "tests"
+      ],
+      "reporter": [
+        "html",
+        "text-summary"
+      ]
+    }

--- a/bedrock-node/main.yml
+++ b/bedrock-node/main.yml
@@ -71,5 +71,5 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:
-        file: ./test/coverage.lcov
+        file: ./test/coverage/lcov.info
         fail_ci_if_error: true

--- a/isomorphic/main.yml
+++ b/isomorphic/main.yml
@@ -69,5 +69,5 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:
-        file: ./coverage.lcov
+        file: ./coverage/lcov.info
         fail_ci_if_error: true


### PR DESCRIPTION
Add some docs.

Switch to using `./coverage/lcov.info`.  (It was already this way in bedrock-web.)  I'd suggest updating current actions to use this location, update `coverage-ci` script targets to use the `lcovonly` reporter, and skip the `> coverage.lcov` thing.  `lcovonly` will output just `lcov.info` rather than the html stuff that CI won't even use.  The redirect was weird as it included npm output and mocha output and then the lcov data was appended at the end.

https://istanbul.js.org/docs/advanced/alternative-reporters/#lcovonly